### PR TITLE
Fix Dependabot security vulnerabilities in pip and wheel

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
-pip==21.1
+pip>=26.0
 bump2version==0.5.11
-wheel==0.33.6
+wheel>=0.38.1
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0


### PR DESCRIPTION
## Summary
- Update `pip` from `==21.1` to `>=26.0` to fix 3 CVEs:
  - **CVE-2023-5752** (medium): Command injection when used with Mercurial
  - **CVE-2025-8869** (medium): Symlink tar extraction directory escape
  - **CVE-2026-1703** (low): Path traversal vulnerability
- Update `wheel` from `==0.33.6` to `>=0.38.1` to fix:
  - **CVE-2022-40898** (high): Regular Expression denial of service (ReDoS)

All 4 alerts are from GitHub Dependabot in `requirements_dev.txt`.